### PR TITLE
Keep more data on CPU because that's good for grain dataloader and datasets.

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - name: Checkout code
@@ -60,7 +60,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install ".[dev]"
         pip install git+https://github.com/DBraun/argbind.git@improve.subclasses
-        pip install git+https://github.com/DBraun/jaxloudnorm.git@feature/speed-optimize
+        pip install git+https://github.com/boris-kuz/jaxloudnorm.git
         pip install git+https://github.com/DBraun/dm_aux.git@DBraun-patch-1
         pip install furo
 

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]  # grain doesn't support Python 3.13 yet.
 
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Change log
+
+## Unreleased
+
+## audiotree 0.2.0 (Feb 17, 2025)
+
+* `jit` has been removed in most places. We encourage users to jit as late as possible, and DAC-JAX demonstrates this.
+* New class: `AudioDataBalancedDataset`, which is a grain Dataset, **not a Data Source**. 
+* `AudioTree` has a `.latents` property.
+* New transform: `NeuralLatentEncodeTransform`.
+* Class `NeuralAudioCodecEncodeTransform` has been adjusted. The arg is now `encoder_fn` and it takes an `AudioTree` instead of an audio data array.
+* In an `AudioTree`'s metadata, the offset and duration will now be 1D arrays instead of 0D arrays.
+* `cpu` has a kwarg has been removed in most places. You should think of AudioTrees as existing on CPU by default. If you pass them to a jitted function then they will be put on device.
+* In, `AudioDataSimpleSource` and `AudioDataBalancedSource`, `num_steps` arg is now `num_records`. Also `._filepaths` property is now `.filepaths`.
+
+## audiotree 0.1.0 (Aug 22, 2024)
+
+### **Breaking changes:**
+* `SaliencyParams` has moved from `audiotree.datasources.SaliencyParams` to `audiotree.SaliencyParams`
+
+### Updates:
+The code has been tested with device parallel sharding.
+See the recent updates to [DAC-JAX](https://github.com/DBraun/DAC-JAX/blob/main/scripts/input_pipeline.py).
+SaliencyParams has a new `search_function` parameter.
+The two valid strings are `SaliencyParams.search_uniform` and `SaliencyParams.search_early_bias`.
+You can also plug in your own Callable function.
+
+## audiotree 0.0.5 (Aug 8, 2024)
+
+First release.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
   given-names: "David"
   orcid: "https://orcid.org/0000-0001-8866-0756"
 title: "AudioTree"
-version: 0.1.1
-date-released: 2024-08-25
+version: 0.2.0
+date-released: 2025-02-13
 url: "https://github.com/DBraun/audiotree"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,7 @@ AudioTree documentation
 
 **AudioTree** is a `JAX <https://jax.readthedocs.io/en/latest/>`_ library for audio data loading and augmentations.
 The source code is `here <https://github.com/DBraun/audiotree>`_.
+AudioTree follows `Effort-based Versioning <https://jacobtomlinson.dev/effver/>`_.
 
 There are three requirements:
 
@@ -68,13 +69,13 @@ Citation
 
 .. code-block::
 
-   @software{Braun_AudioTree_2024,
+   @software{Braun_AudioTree_2025,
       author = {Braun, David},
       month = aug,
       title = {{AudioTree}},
       url = {https://github.com/DBraun/audiotree},
-      version = {0.1.2},
-      year = {2024}
+      version = {0.2.0},
+      year = {2025}
    }
 
 .. _flax.struct.dataclass: https://flax.readthedocs.io/en/latest/api_reference/flax.struct.html#flax.struct.dataclass

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ There are three requirements:
 
    pip install "git+https://github.com/DBraun/argbind.git@improve.subclasses"
    pip install "git+https://github.com/DBraun/dm_aux.git@DBraun-patch-2"
-   pip install "git+https://github.com/DBraun/jaxloudnorm.git@feature/speed-optimize"
+   pip install "git+https://github.com/boris-kuz/jaxloudnorm.git"
 
 Then AudioTree can be installed with pip:
 
@@ -20,7 +20,8 @@ Then AudioTree can be installed with pip:
    pip install audiotree
 
 The namesake class :class:`~audiotree.core.AudioTree` is a `flax.struct.dataclass`_ with properties for audio data,
-sample rate, on-demand data such as loudness, and optional metadata such as MIDI pitch, velocity, and duration.
+sample rate, on-demand data such as loudness, and optional data such as filepaths, MIDI pitch, velocity, and duration.
+An AudioTree can also store arrays for codebooks or latent embeddings.
 
 Although ``AudioTree`` is a specific class, we loosely refer to any combination of dictionaries and lists of
 ``AudioTrees`` as also an ``AudioTree`` (check out the `Pytree`_ JAX docs).
@@ -38,7 +39,7 @@ For example, in the code below, we consider ``batch`` to be an ``AudioTree``.
 The batch above can be used with `jax.tree.map`_ to create a new batch. That's essentially what the Transform classes in
 :mod:`~audiotree.transforms` do.
 They perform GPU-based `jax.jit`_-compatible augmentations on arbitrarily shaped AudioTrees.
-When used with `ArgBind`_, they are also highly configurable from the command-line and YAML.
+When used with `ArgBind`_, they are also highly configurable from the command-line, YAML and Python.
 
 Whether you're creating a data loader for training, validation, testing, or prompt generation, AudioTree can help.
 

--- a/docs/source/introduction/datasources.rst
+++ b/docs/source/introduction/datasources.rst
@@ -16,10 +16,10 @@ Data Sources
 Data Sources in ``audiotree.datasources`` are `Grain`_ `data sources <https://github.com/google/grain/blob/main/docs/data_sources.md>`_
 that are specially designed for audio. Grain is a new library for dataset operations in JAX with no TensorFlow dependency.
 
-For now, there are only two types of Data Sources, but they fit many needs.
+For now, there are only two types of Data Sources and one Data Set, but they fit many needs.
 You can take a look at DAC-JAX's `input_pipeline.py <https://github.com/DBraun/DAC-JAX/blob/main/scripts/input_pipeline.py>`_ to see how they're used.
 
-Both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedDataset` are initialized with a dictionary of ``sources``.
+The three :class:`~audiotree.datasources.core.AudioDataSimpleSource`, :class:`~audiotree.datasources.core.AudioDataBalancedSource`, and :class:`~audiotree.datasources.core.AudioDataBalancedDataset` are initialized with a dictionary of ``sources``.
 For example, with ArgBind, the YAML might be this (adapted from `DAC <https://github.com/descriptinc/descript-audio-codec/blob/main/conf/base.yml>`_):
 
 .. code-block:: yaml
@@ -49,7 +49,7 @@ For example, with ArgBind, the YAML might be this (adapted from `DAC <https://gi
             - /data/audioset/data/unbalanced_train_segments/
             - /data/audioset/data/balanced_train_segments/
 
-The second thing to know is that both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedDataset`
+The second thing to know is that :class:`~audiotree.datasources.core.AudioDataSimpleSource`, :class:`~audiotree.datasources.core.AudioDataBalancedSource`, and :class:`~audiotree.datasources.core.AudioDataBalancedDataset`
 can be initialized with an instance of :class:`~audiotree.datasources.core.SaliencyParams`. If :class:`~audiotree.datasources.core.SaliencyParams` has ``enabled``
 set to ``True``, then a random section of an audio file will be selected until it meets a specified minimum loudness.
 

--- a/docs/source/introduction/datasources.rst
+++ b/docs/source/introduction/datasources.rst
@@ -19,11 +19,14 @@ that are specially designed for audio. Grain is a new library for dataset operat
 For now, there are only two types of Data Sources, but they fit many needs.
 You can take a look at DAC-JAX's `input_pipeline.py <https://github.com/DBraun/DAC-JAX/blob/main/scripts/input_pipeline.py>`_ to see how they're used.
 
-Both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedSource` are initialized with a dictionary of ``sources``.
+Both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedDataset` are initialized with a dictionary of ``sources``.
 For example, with ArgBind, the YAML might be this (adapted from `DAC <https://github.com/descriptinc/descript-audio-codec/blob/main/conf/base.yml>`_):
 
 .. code-block:: yaml
-    
+
+    train/AudioDataSimpleSource.extensions:
+        - .wav
+        - .flac
     train/AudioDataSimpleSource.sources:
         speech_fb:
             - /data/daps/train
@@ -46,7 +49,7 @@ For example, with ArgBind, the YAML might be this (adapted from `DAC <https://gi
             - /data/audioset/data/unbalanced_train_segments/
             - /data/audioset/data/balanced_train_segments/
 
-The second thing to know is that both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedSource`
+The second thing to know is that both :class:`~audiotree.datasources.core.AudioDataSimpleSource` and :class:`~audiotree.datasources.core.AudioDataBalancedDataset`
 can be initialized with an instance of :class:`~audiotree.datasources.core.SaliencyParams`. If :class:`~audiotree.datasources.core.SaliencyParams` has ``enabled``
 set to ``True``, then a random section of an audio file will be selected until it meets a specified minimum loudness.
 

--- a/docs/source/introduction/datasources.rst
+++ b/docs/source/introduction/datasources.rst
@@ -24,10 +24,10 @@ For example, with ArgBind, the YAML might be this (adapted from `DAC <https://gi
 
 .. code-block:: yaml
 
-    train/AudioDataSimpleSource.extensions:
+    train/AudioDataBalancedSource.extensions:
         - .wav
         - .flac
-    train/AudioDataSimpleSource.sources:
+    train/AudioDataBalancedSource.sources:
         speech_fb:
             - /data/daps/train
         speech_hq:
@@ -48,6 +48,21 @@ For example, with ArgBind, the YAML might be this (adapted from `DAC <https://gi
         general:
             - /data/audioset/data/unbalanced_train_segments/
             - /data/audioset/data/balanced_train_segments/
+
+The folders can also be glob expressions (due to the balancing, the result is different from the above):
+
+.. code-block:: yaml
+
+    train/AudioDataBalancedSource.sources:
+        speech:
+            - /data/*speech/**/*.wav
+            - /data/daps/train
+            - /data/vctk
+            - /data/vocalset
+            - /data/common_voice
+        music:
+            - /data/musdb/train
+            - /data/jamendo
 
 The second thing to know is that :class:`~audiotree.datasources.core.AudioDataSimpleSource`, :class:`~audiotree.datasources.core.AudioDataBalancedSource`, and :class:`~audiotree.datasources.core.AudioDataBalancedDataset`
 can be initialized with an instance of :class:`~audiotree.datasources.core.SaliencyParams`. If :class:`~audiotree.datasources.core.SaliencyParams` has ``enabled``

--- a/docs/source/introduction/transforms.rst
+++ b/docs/source/introduction/transforms.rst
@@ -34,8 +34,8 @@ Before transformations, your data source might provide a single :class:`~audiotr
 
     from jax import numpy as jnp
     from audiotree import AudioTree
-    sample_rate = 44100
-    data = jnp.zeros((16, 2, 441000))  # dummy placeholder shaped (B, C, T)
+    sample_rate = 44_100
+    data = jnp.zeros((16, 2, 441_000))  # dummy placeholder shaped (B, C, T)
     audio_tree = AudioTree(data, sample_rate)
     batch = {"src": [audio_tree, audio_tree], "target": audio_tree}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Multimedia :: Sound/Audio
     Topic :: Software Development :: Libraries
 
@@ -22,12 +23,10 @@ package_dir =
 packages = find:
 python_requires = >=3.10
 install_requires =
-    chex>=0.1.86
 ;    dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-1
     einops
-    flax>=0.8.2
-    grain==0.2.*
-;    jaxloudnorm @ git+https://github.com/DBraun/jaxloudnorm.git@feature/speed-optimize
+    jax-ai-stack>=2025.1.9
+;    jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1
     numpy
     soundfile

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ python_requires = >=3.10
 install_requires =
 ;    dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-1
     einops
+    grain>=0.2.*
     jax-ai-stack>=2025.1.9
 ;    jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ python_requires = >=3.10
 install_requires =
 ;    dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-1
     einops
-    grain>=0.2.0
-    jax-ai-stack>=2025.1.9
+    grain>=0.2.3
+    jax-ai-stack>=2025.2.5
 ;    jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
     Topic :: Multimedia :: Sound/Audio
     Topic :: Software Development :: Libraries
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.10
 install_requires =
 ;    dm_aux @ git+https://github.com/DBraun/dm_aux.git@DBraun-patch-1
     einops
-    grain>=0.2.*
+    grain>=0.2.0
     jax-ai-stack>=2025.1.9
 ;    jaxloudnorm @ git+https://github.com/boris-kuz/jaxloudnorm.git
     librosa>=0.10.1

--- a/src/audiotree/__init__.py
+++ b/src/audiotree/__init__.py
@@ -1,4 +1,14 @@
-__version__ = "0.1.2"
-# Don't move the line above. It must be the first line due to `docs/source/conf.py`
+__version__ = "0.2.0"
+__author__ = "David Braun"
+# Effort-based versioning. Don't move the line above. It must be the first line due to `docs/source/conf.py`
 from .core import AudioTree
 from .core import SaliencyParams
+from . import datasources
+from . import transforms
+
+__all__ = [
+    "AudioTree",
+    "SaliencyParams",
+    "datasources",
+    "transforms",
+]

--- a/src/audiotree/core.py
+++ b/src/audiotree/core.py
@@ -103,7 +103,9 @@ class AudioTree:
 
     def replace_loudness(self) -> Self:
         """Replace ``loudness`` property with a JAX scalar."""
-        loudness = jit_integrated_loudness(self.audio_data, self.sample_rate, zeros=512)
+        loudness = jit_integrated_loudness(
+            jnp.array(self.audio_data), self.sample_rate, zeros=512
+        )
         return self.replace(loudness=loudness)
 
     @staticmethod
@@ -131,7 +133,6 @@ class AudioTree:
         offset: float = 0.0,
         duration: float = None,
         mono: bool = False,
-        cpu: bool = True,
     ):
         """Create an AudioTree from an audio file path.
 
@@ -143,7 +144,6 @@ class AudioTree:
             duration (float, optional): Duration in seconds of audio data. The audio data will be trimmed or extended as
                 necessary.
             mono (bool, optional): Whether to force the audio data to be single-channel.
-            cpu (bool, optional): Whether to keep the audio data in CPU RAM (not GPU/TPU etc.)
 
         Returns:
             AudioTree: An instance of ``AudioTree``.
@@ -160,9 +160,6 @@ class AudioTree:
         if duration is not None and data.shape[-1] < round(duration * sample_rate):
             pad_right = round(duration * sample_rate) - data.shape[-1]
             data = np.pad(data, ((0, 0), (0, 0), (0, pad_right)))
-
-        if not cpu:
-            data = jnp.array(data, dtype=jnp.float32)
 
         return cls(
             audio_data=data,
@@ -286,6 +283,11 @@ class AudioTree:
                 current_try += 1
                 if num_tries is not None and current_try >= num_tries:
                     break
+
+        # todo: revisit whether casting to numpy here actually prevents any slowdown with grain.
+        excerpt = excerpt.replace(
+            audio_data=np.array(excerpt.audio_data), loudness=np.array(excerpt.loudness)
+        )
         return excerpt
 
     def to_mono(self) -> Self:

--- a/src/audiotree/core.py
+++ b/src/audiotree/core.py
@@ -30,7 +30,7 @@ class SaliencyParams:
 
     enabled: bool = field(default=False)
     num_tries: int = 8
-    loudness_cutoff: float = -40
+    loudness_cutoff: float = -40.0
 
     # Note: Although Union[Callable, str] would be a better type annotation, it doesn't work well with argbind
     search_function: str = "SaliencyParams.search_uniform"
@@ -81,22 +81,24 @@ class AudioTree:
     Args:
         audio_data (jnp.ndarray): Audio waveform data in JAX numpy tensor shaped ``(Batch, Channels, Samples)``
         sample_rate (int): Sample rate of ``audio_data``, such as 44100 Hz.
-        loudness (float, optional): Loudness of the audio waveform in LUFs. Don't set this when initializing. Instead,
+        loudness (jnp.ndarray, optional): Loudness of the audio waveform in LUFs. You may not need to set this when initializing. Instead,
             use ``replace_loudness()`` to create a new AudioTree with ``loudness`` calculated.
-        pitch (float, optional): The MIDI pitch where 60 is middle C.
-        velocity (float, optional): The MIDI velocity between 0 and 127.
-        duration (float, optional): The duration of the audio waveform in seconds.
-        codes (jnp.ndarray): The neural audio codec tokens for the audio.
+        pitch (jnp.ndarray, optional): The MIDI pitch where 60 is middle C. The shape is ``(Batch,)``.
+        velocity (jnp.ndarray, optional): The MIDI velocity between 0 and 127. The shape is ``(Batch,)``.
+        duration (jnp.ndarray, optional): The duration of the audio waveform in seconds (like a note duration). The shape is ``(Batch,)``.
+        codes (jnp.ndarray, optional): The neural audio codec tokens for the audio.
+        latents (jnp.ndarray, optional): The latent representations of the audio.
         metadata (dict): Any extra metadata can be placed here.
     """
 
-    audio_data: jnp.ndarray
+    audio_data: np.ndarray
     sample_rate: int = struct.field(pytree_node=False)
-    loudness: float = None
-    pitch: float = None
-    velocity: float = None
-    duration: float = None
-    codes: jnp.ndarray = None
+    loudness: np.ndarray = None
+    pitch: np.ndarray = None
+    velocity: np.ndarray = None
+    duration: np.ndarray = None
+    codes: np.ndarray = None
+    latents: np.ndarray = None
     metadata: dict = struct.field(pytree_node=True, default_factory=dict)
 
     def replace_loudness(self) -> Self:
@@ -105,13 +107,13 @@ class AudioTree:
         return self.replace(loudness=loudness)
 
     @staticmethod
-    def _encode_string(s: str):
+    def _encode_string(s: str) -> np.ndarray:
         # Convert string to list of ASCII values and pad with 0
         encoded = [ord(char) for char in s] + [0] * (_str_max_length - len(s))
-        return jnp.array([encoded])  # [1, _str_max_length]
+        return np.array([encoded])  # [1, _str_max_length]
 
     @staticmethod
-    def _decode_string(encoded_array: jnp.ndarray):
+    def _decode_string(encoded_array: np.ndarray) -> str:
         # Convert list of integers to characters and join them into a string
         decoded = "".join([chr(val) for val in encoded_array if val != 0])
         return decoded
@@ -129,7 +131,7 @@ class AudioTree:
         offset: float = 0.0,
         duration: float = None,
         mono: bool = False,
-        cpu: bool = False,
+        cpu: bool = True,
     ):
         """Create an AudioTree from an audio file path.
 
@@ -141,6 +143,7 @@ class AudioTree:
             duration (float, optional): Duration in seconds of audio data. The audio data will be trimmed or extended as
                 necessary.
             mono (bool, optional): Whether to force the audio data to be single-channel.
+            cpu (bool, optional): Whether to keep the audio data in CPU RAM (not GPU/TPU etc.)
 
         Returns:
             AudioTree: An instance of ``AudioTree``.
@@ -166,8 +169,8 @@ class AudioTree:
             sample_rate=sr,
             metadata={
                 "filepath": cls._encode_string(audio_path),
-                "offset": offset,
-                "duration": duration,
+                "offset": np.array([offset]),
+                "duration": np.array([duration]),
             },
         )
 
@@ -176,13 +179,12 @@ class AudioTree:
         """Create an AudioTree from an audio array and a sample rate.
 
         Args:
-            audio_data (jnp.ndarray): Audio data shaped ``(Batch, Channels, Samples)``
+            audio_data (np.ndarray): Audio data shaped ``(Samples)``, ``(Channels, Samples)``, or ``(Batch, Channels, Samples)``
             sample_rate (int): Sample rate of audio data, such as 44100 Hz.
 
         Returns:
             AudioTree: An instance of ``AudioTree``.
         """
-        audio_data = jnp.array(audio_data, dtype=jnp.float32)
         if audio_data.ndim == 1:
             audio_data = audio_data[None, None, :]  # Add batch and channel dimension
         elif audio_data.ndim == 2:

--- a/src/audiotree/datasources/__init__.py
+++ b/src/audiotree/datasources/__init__.py
@@ -1,9 +1,11 @@
 from .core import AudioDataSourceMixin
+from .core import AudioDataBalancedSource
 from .core import AudioDataBalancedDataset
 from .core import AudioDataSimpleSource
 
 __all__ = [
     "AudioDataSourceMixin",
+    "AudioDataBalancedSource",
     "AudioDataBalancedDataset",
     "AudioDataSimpleSource",
 ]

--- a/src/audiotree/datasources/__init__.py
+++ b/src/audiotree/datasources/__init__.py
@@ -1,9 +1,9 @@
 from .core import AudioDataSourceMixin
-from .core import AudioDataBalancedSource
+from .core import AudioDataBalancedDataset
 from .core import AudioDataSimpleSource
 
 __all__ = [
     "AudioDataSourceMixin",
-    "AudioDataBalancedSource",
+    "AudioDataBalancedDataset",
     "AudioDataSimpleSource",
 ]

--- a/src/audiotree/datasources/__init__.py
+++ b/src/audiotree/datasources/__init__.py
@@ -1,3 +1,9 @@
 from .core import AudioDataSourceMixin
 from .core import AudioDataBalancedSource
 from .core import AudioDataSimpleSource
+
+__all__ = [
+    "AudioDataSourceMixin",
+    "AudioDataBalancedSource",
+    "AudioDataSimpleSource",
+]

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -1,9 +1,8 @@
 import glob
-import math
 import os
-from random import Random
 from typing import AnyStr, List, Mapping, SupportsIndex
 
+from grain._src.python.dataset.transformations.mix import MixedIterDataset
 from grain import python as grain
 import numpy as np
 
@@ -67,7 +66,7 @@ class AudioDataSourceMixin:
                 sample_rate=self.sample_rate,
                 duration=self.duration,
                 mono=self.mono,
-                cpu=self.cpu,
+                cpu=False,
             )
 
         return AudioTree.from_file(
@@ -76,7 +75,6 @@ class AudioDataSourceMixin:
             offset=0,
             duration=self.duration,
             mono=self.mono,
-            cpu=self.cpu,
         )
 
 
@@ -91,7 +89,6 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         duration (float): The requested duration of the audio.
         extensions (List[str]): A list of file extensions to search for. Each extension should include a period.
         saliency_params (SaliencyParams): Saliency parameters to use.
-        cpu (bool): Whether to load the audio data on the CPU.
     """
 
     def __init__(
@@ -103,7 +100,6 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         duration: float = 1.0,
         extensions: List[str] = None,
         saliency_params: SaliencyParams = None,
-        cpu: bool = False,
     ):
 
         self.sample_rate = sample_rate
@@ -112,7 +108,6 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         if extensions is None:
             extensions = _default_extensions
         self.saliency_params = saliency_params
-        self.cpu = cpu
 
         filepaths = []
         for group_name, folders in sources.items():
@@ -151,95 +146,58 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         return self.load_audio(file_path, record_key)
 
 
-class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
+class AudioDataBalancedDataset(MixedIterDataset):
     """A Data Source that equally weights multiple sources, where each source is a list of directories.
 
     Args:
         sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
-        num_steps (int): The requested length of the data source.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
         duration (float): The requested duration of the audio.
         extensions (List[str]): A list of file extensions to search for. Each extension should include a period.
         saliency_params (SaliencyParams): Saliency parameters to use.
-        cpu (bool): Whether to load the audio data on the CPU.
+        weights (Mapping[str, float]): A dictionary mapping each source to its proportion in the dataset.
     """
-
-    # todo: make this algorithm work if the user specifies weights for the groups.
-    #  Right now the groups are balanced uniformly.
-    #  Eventually the __init__ should just take a list of ``AudioDataSimpleSource`` and
-    #  the corresponding weights.
 
     def __init__(
         self,
         sources: Mapping[str, List[str]],
-        num_steps: int,
-        sample_rate: int = 44100,
+        sample_rate: int = 44_100,
         mono: int = 1,
         duration: float = 1.0,
         extensions: List[str] = None,
         saliency_params: SaliencyParams = None,
-        cpu: bool = False,
+        weights: Mapping[str, float] = None,
     ):
-
         self.sample_rate = sample_rate
         self.mono = bool(mono)
         self.duration = duration
         if extensions is None:
             extensions = _default_extensions
         self.saliency_params = saliency_params
-        self.cpu = cpu
 
-        groups = []
+        datasets = []
 
-        for group_name, folders in sources.items():
-            filepaths = []
-            for _folder in folders:
-                folder = os.path.expandvars(os.path.expanduser(_folder))
-                if os.path.isdir(os.path.expandvars(os.path.expanduser(folder))):
-                    filepaths += _find_files_with_extensions(
-                        folder, extensions=extensions
-                    )
-                else:
-                    filepaths += list(glob.glob(folder))
-
-            if filepaths:
-                groups.append(filepaths)
-            else:
-                raise RuntimeError(
-                    f"Group '{group_name}' is empty. "
-                    f"The number of specified folders in the group was {len(folders)}. "
-                    f"The approved file extensions were {extensions}."
-                )
-
-        self._num_groups = len(groups)
-        self._length = num_steps
-
-        ideal_group_length = math.ceil(num_steps / self._num_groups)
         seed = 0
-        lengthened_groups = []
-        for group in groups:
-            num_loops = math.ceil(ideal_group_length / len(group))
-            lengthened_group = []
-            for _ in range(num_loops):
-                copied = group.copy()
-                Random(seed).shuffle(copied)
-                seed += 1
-                lengthened_group += copied
-            lengthened_groups.append(lengthened_group)
-        self._groups = lengthened_groups
+        proportions = []
+        for group_name, folders in sources.items():
+            datasource = AudioDataSimpleSource(
+                sources={group_name: folders},
+                num_steps=None,
+                sample_rate=sample_rate,
+                mono=mono,
+                duration=duration,
+                extensions=extensions,
+                saliency_params=saliency_params,
+            )
+            dataset = (
+                grain.MapDataset.source(datasource)
+                .shuffle(seed=seed)
+                .repeat()
+                .to_iter_dataset()
+            )
+            seed += 1
+            datasets.append(dataset)
+            proportions.append(weights.get(group_name, 1.0)*1000)
 
-        assert self._length > 0
-
-    def __len__(self) -> int:
-        return self._length
-
-    def __getitem__(self, record_key: SupportsIndex):
-        record_key = int(record_key)
-
-        group_idx = record_key % self._num_groups
-        idx = record_key // self._num_groups
-
-        file_path = self._groups[group_idx][idx]
-
-        return self.load_audio(file_path, record_key)
+        super().__init__(datasets, proportions=proportions)

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -68,7 +68,6 @@ class AudioDataSourceMixin:
                 sample_rate=self.sample_rate,
                 duration=self.duration,
                 mono=self.mono,
-                cpu=False,
             )
 
         return AudioTree.from_file(

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -1,5 +1,7 @@
 import glob
+import math
 import os
+from random import Random
 from typing import AnyStr, List, Mapping, SupportsIndex
 
 from grain._src.python.dataset.transformations.mix import MixedIterDataset
@@ -146,6 +148,97 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         return self.load_audio(file_path, record_key)
 
 
+class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
+    """A Data Source that equally weights multiple sources, where each source is a list of directories.
+
+    Args:
+        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
+        num_steps (int): The requested length of the data source.
+        sample_rate (int): The requested sample rate of the audio.
+        mono (bool): Whether to force the audio to be mono.
+        duration (float): The requested duration of the audio.
+        extensions (List[str]): A list of file extensions to search for. Each extension should include a period.
+        saliency_params (SaliencyParams): Saliency parameters to use.
+    """
+
+    # todo: make this algorithm work if the user specifies weights for the groups.
+    #  Right now the groups are balanced uniformly.
+    #  Eventually the __init__ should just take a list of ``AudioDataSimpleSource`` and
+    #  the corresponding weights.
+
+    def __init__(
+        self,
+        sources: Mapping[str, List[str]],
+        num_steps: int,
+        sample_rate: int = 44100,
+        mono: int = 1,
+        duration: float = 1.0,
+        extensions: List[str] = None,
+        saliency_params: SaliencyParams = None,
+    ):
+
+        self.sample_rate = sample_rate
+        self.mono = bool(mono)
+        self.duration = duration
+        if extensions is None:
+            extensions = _default_extensions
+        self.saliency_params = saliency_params
+
+        groups = []
+
+        for group_name, folders in sources.items():
+            filepaths = []
+            for _folder in folders:
+                folder = os.path.expandvars(os.path.expanduser(_folder))
+                if os.path.isdir(os.path.expandvars(os.path.expanduser(folder))):
+                    filepaths += _find_files_with_extensions(
+                        folder, extensions=extensions
+                    )
+                else:
+                    filepaths += list(glob.glob(folder))
+
+            if filepaths:
+                groups.append(filepaths)
+            else:
+                raise RuntimeError(
+                    f"Group '{group_name}' is empty. "
+                    f"The number of specified folders in the group was {len(folders)}. "
+                    f"The approved file extensions were {extensions}."
+                )
+
+        self._num_groups = len(groups)
+        self._length = num_steps
+
+        ideal_group_length = math.ceil(num_steps / self._num_groups)
+        seed = 0
+        lengthened_groups = []
+        for group in groups:
+            num_loops = math.ceil(ideal_group_length / len(group))
+            lengthened_group = []
+            for _ in range(num_loops):
+                copied = group.copy()
+                Random(seed).shuffle(copied)
+                seed += 1
+                lengthened_group += copied
+            lengthened_groups.append(lengthened_group)
+        self._groups = lengthened_groups
+
+        assert self._length > 0
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __getitem__(self, record_key: SupportsIndex):
+        record_key = int(record_key)
+
+        group_idx = record_key % self._num_groups
+        idx = record_key // self._num_groups
+
+        file_path = self._groups[group_idx][idx]
+
+        return self.load_audio(file_path, record_key)
+
+
 class AudioDataBalancedDataset(MixedIterDataset):
     """A Data Source that equally weights multiple sources, where each source is a list of directories.
 
@@ -198,6 +291,9 @@ class AudioDataBalancedDataset(MixedIterDataset):
             )
             seed += 1
             datasets.append(dataset)
-            proportions.append(weights.get(group_name, 1.0)*1000)
+            weight = 1.0
+            if isinstance(weights, dict):
+                weight = weights.get(group_name, 1.0)
+            proportions.append(weight*1000)
 
         super().__init__(datasets, proportions=proportions)

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -124,7 +124,7 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
                         folder, extensions=extensions
                     )
                 else:
-                    filepaths_in_group = list(glob.glob(folder))
+                    filepaths_in_group = list(glob.glob(folder, recursive=True))
 
             if filepaths_in_group:
                 filepaths += filepaths_in_group

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -85,7 +85,7 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
 
     Args:
         sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
-        num_steps (int): The requested length of the data source.
+        num_records (int): The requested length of the data source.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
         duration (float): The requested duration of the audio.
@@ -96,8 +96,8 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
     def __init__(
         self,
         sources: Mapping[str, List[str]],
-        num_steps: int = None,
-        sample_rate: int = 44100,
+        num_records: int = None,
+        sample_rate: int = 44_100,
         mono: int = 1,
         duration: float = 1.0,
         extensions: List[str] = None,
@@ -132,10 +132,10 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
                     f"The approved file extensions were {extensions}."
                 )
 
-        if num_steps is not None:
-            filepaths = filepaths[:num_steps]
+        if num_records is not None:
+            filepaths = filepaths[:num_records]
 
-        self._file_paths = filepaths
+        self.filepaths = filepaths
 
         self._length = len(filepaths)
         assert self._length > 0
@@ -144,7 +144,7 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
         return self._length
 
     def __getitem__(self, record_key: SupportsIndex):
-        file_path = self._file_paths[record_key]
+        file_path = self.filepaths[record_key]
         return self.load_audio(file_path, record_key)
 
 
@@ -153,7 +153,7 @@ class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin
 
     Args:
         sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
-        num_steps (int): The requested length of the data source.
+        num_records (int): The requested length of the data source.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
         duration (float): The requested duration of the audio.
@@ -165,12 +165,14 @@ class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin
     #  Right now the groups are balanced uniformly.
     #  Eventually the __init__ should just take a list of ``AudioDataSimpleSource`` and
     #  the corresponding weights.
+    #  AudioDataBalancedDataset accomplishes this, but since it's an IterDataset it doesn't have all the features
+    #  of a plain RandomAccessDataSource.
 
     def __init__(
         self,
         sources: Mapping[str, List[str]],
-        num_steps: int,
-        sample_rate: int = 44100,
+        num_records: int,
+        sample_rate: int = 44_100,
         mono: int = 1,
         duration: float = 1.0,
         extensions: List[str] = None,
@@ -207,9 +209,9 @@ class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin
                 )
 
         self._num_groups = len(groups)
-        self._length = num_steps
+        self._length = num_records
 
-        ideal_group_length = math.ceil(num_steps / self._num_groups)
+        ideal_group_length = math.ceil(num_records / self._num_groups)
         seed = 0
         lengthened_groups = []
         for group in groups:
@@ -276,7 +278,7 @@ class AudioDataBalancedDataset(MixedIterDataset):
         for group_name, folders in sources.items():
             datasource = AudioDataSimpleSource(
                 sources={group_name: folders},
-                num_steps=None,
+                num_records=None,
                 sample_rate=sample_rate,
                 mono=mono,
                 duration=duration,
@@ -294,6 +296,6 @@ class AudioDataBalancedDataset(MixedIterDataset):
             weight = 1.0
             if isinstance(weights, dict):
                 weight = weights.get(group_name, 1.0)
-            proportions.append(weight*1000)
+            proportions.append(weight * 1000)
 
         super().__init__(datasets, proportions=proportions)

--- a/src/audiotree/datasources/core.py
+++ b/src/audiotree/datasources/core.py
@@ -84,7 +84,8 @@ class AudioDataSimpleSource(grain.RandomAccessDataSource, AudioDataSourceMixin):
     """A Data Source that aggregates all source files and weights them equally.
 
     Args:
-        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
+        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories or glob
+            expressions involving a file extension.
         num_records (int): The requested length of the data source.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
@@ -152,7 +153,8 @@ class AudioDataBalancedSource(grain.RandomAccessDataSource, AudioDataSourceMixin
     """A Data Source that equally weights multiple sources, where each source is a list of directories.
 
     Args:
-        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
+        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories or glob
+            expressions involving a file extension.
         num_records (int): The requested length of the data source.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
@@ -245,7 +247,8 @@ class AudioDataBalancedDataset(MixedIterDataset):
     """A Data Source that equally weights multiple sources, where each source is a list of directories.
 
     Args:
-        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories.
+        sources (Mapping[str, List[str]]): A dictionary mapping each source to a list of directories or glob
+            expressions involving a file extension.
         sample_rate (int): The requested sample rate of the audio.
         mono (bool): Whether to force the audio to be mono.
         duration (float): The requested duration of the audio.

--- a/src/audiotree/loudness.py
+++ b/src/audiotree/loudness.py
@@ -7,7 +7,7 @@ from jax import numpy as jnp
 
 
 @partial(jax.jit, static_argnames=("sample_rate", "zeros"))
-def jit_integrated_loudness(data, sample_rate, zeros: int):
+def jit_integrated_loudness(data: jnp.ndarray, sample_rate: int, zeros: int):
 
     block_size = 0.4
 

--- a/src/audiotree/transforms/__init__.py
+++ b/src/audiotree/transforms/__init__.py
@@ -8,4 +8,20 @@ from .core import CorruptPhase
 from .core import ShiftPhase
 from .core import Choose
 from .core import NeuralAudioCodecEncodeTransform
+from .core import NeuralLatentEncodeTransform
 from .core import ReduceBatchTransform
+
+__all__ = [
+    "Identity",
+    "VolumeChange",
+    "VolumeNorm",
+    "RescaleAudio",
+    "InvertPhase",
+    "SwapStereo",
+    "CorruptPhase",
+    "ShiftPhase",
+    "Choose",
+    "NeuralAudioCodecEncodeTransform",
+    "NeuralLatentEncodeTransform",
+    "ReduceBatchTransform",
+]

--- a/src/audiotree/transforms/base.py
+++ b/src/audiotree/transforms/base.py
@@ -4,7 +4,7 @@ import warnings
 from grain.python import MapTransform, RandomMapTransform
 import jax
 from jax import random
-from jax.tree_util import DictKey, tree_map_with_path
+from jax.tree_util import DictKey, tree_map_with_path, tree_map
 import numpy as np
 
 from audiotree import AudioTree
@@ -76,7 +76,7 @@ def merge_pytree(tree1, tree2):
     def _combine(x, y):
         return {**x, **y}
 
-    return jax.tree_util.tree_map(_combine, tree1, tree2, is_leaf=is_leaf)
+    return tree_map(_combine, tree1, tree2, is_leaf=is_leaf)
 
 
 class BaseTransformMixIn:

--- a/src/audiotree/transforms/base.py
+++ b/src/audiotree/transforms/base.py
@@ -4,7 +4,8 @@ import warnings
 from grain.python import MapTransform, RandomMapTransform
 import jax
 from jax import random
-from jax.tree_util import DictKey, tree_map_with_path, tree_map
+from jax.tree import map_with_path
+from jax.tree_util import DictKey
 import numpy as np
 
 from audiotree import AudioTree
@@ -76,7 +77,7 @@ def merge_pytree(tree1, tree2):
     def _combine(x, y):
         return {**x, **y}
 
-    return tree_map(_combine, tree1, tree2, is_leaf=is_leaf)
+    return jax.tree.map(_combine, tree1, tree2, is_leaf=is_leaf)
 
 
 class BaseTransformMixIn:
@@ -140,7 +141,7 @@ class BaseTransformMixIn:
             return leaf
 
         # Rename the deepest keys in the new tree using the `output_key` function.
-        new_tree = tree_map_with_path(rename_node, new_tree, is_leaf=is_leaf)
+        new_tree = map_with_path(rename_node, new_tree, is_leaf=is_leaf)
 
         # Merge the trees. Unfortunately, the order matters.
         new_tree = merge_pytree(new_tree, old_tree)
@@ -205,6 +206,10 @@ class BaseRandomTransform(BaseTransformMixIn, RandomMapTransform):
             seed = rng.integers(2**63)
             key = random.PRNGKey(seed)
 
+        def is_leaf(leaf):
+            res = isinstance(leaf, AudioTree)  # todo: ask JAX experts about this
+            return res
+
         def pre_transform_map_func(path: list[DictKey], leaf):
             if _is_in_scope(self.scope, path):
                 transformed_leaf = self._pre_transform(leaf)
@@ -212,6 +217,8 @@ class BaseRandomTransform(BaseTransformMixIn, RandomMapTransform):
             return leaf
 
         def map_func(path: list[DictKey], leaf, rng: jax.Array, *config):
+            if not is_leaf(leaf):
+                return leaf
             if _is_in_scope(self.scope, path):
                 transformed_leaf = self._apply_transform(leaf, rng, **config[0])
                 return transformed_leaf
@@ -229,23 +236,16 @@ class BaseRandomTransform(BaseTransformMixIn, RandomMapTransform):
                 for key, default in self.default_config.items()
             }
 
-        def is_leaf(leaf):
-            return isinstance(leaf, AudioTree)  # todo: ask JAX experts about this
-
-        element = tree_map_with_path(pre_transform_map_func, element, is_leaf=is_leaf)
+        element = map_with_path(pre_transform_map_func, element, is_leaf=is_leaf)
 
         treedef = jax.tree.flatten(element, is_leaf=is_leaf)[1]
         length = treedef.num_leaves
         subkeys = random.split(key, length) if self.split_seed else [key] * length
         subkeys = jax.tree.unflatten(treedef, subkeys)
 
-        config = tree_map_with_path(
-            map_use_default_config_val, element, is_leaf=is_leaf
-        )
+        config = map_with_path(map_use_default_config_val, element, is_leaf=is_leaf)
 
-        new_tree = tree_map_with_path(
-            map_func, element, subkeys, config, is_leaf=is_leaf
-        )
+        new_tree = map_with_path(map_func, element, subkeys, config, is_leaf=is_leaf)
         new_tree = self._post_process(element, new_tree)
 
         # Determine if we should apply the transform
@@ -297,13 +297,21 @@ class BaseMapTransform(BaseTransformMixIn, MapTransform):
             Any: transformed element
         """
 
+        def is_leaf(leaf):
+            res = isinstance(leaf, AudioTree)  # todo: ask JAX experts about this
+            return res
+
         def pre_transform_map_func(path: list[DictKey], leaf):
+            if not is_leaf(leaf):
+                return leaf
             if _is_in_scope(self.scope, path):
                 transformed_leaf = self._pre_transform(leaf)
                 return transformed_leaf
             return leaf
 
         def map_func(path: list[DictKey], leaf, *config):
+            if not is_leaf(leaf):
+                return leaf
             if _is_in_scope(self.scope, path):
                 transformed_leaf = self._apply_transform(leaf, **config[0])
                 return transformed_leaf
@@ -321,13 +329,8 @@ class BaseMapTransform(BaseTransformMixIn, MapTransform):
                 for key, default in self.default_config.items()
             }
 
-        def is_leaf(leaf):
-            return isinstance(leaf, AudioTree)  # todo: ask JAX experts about this
+        element = map_with_path(pre_transform_map_func, element, is_leaf=is_leaf)
 
-        element = tree_map_with_path(pre_transform_map_func, element, is_leaf=is_leaf)
-
-        config = tree_map_with_path(
-            map_use_default_config_val, element, is_leaf=is_leaf
-        )
-        new_tree = tree_map_with_path(map_func, element, config, is_leaf=is_leaf)
+        config = map_with_path(map_use_default_config_val, element, is_leaf=is_leaf)
+        new_tree = map_with_path(map_func, element, config, is_leaf=is_leaf)
         return self._post_process(element, new_tree)

--- a/src/audiotree/transforms/core.py
+++ b/src/audiotree/transforms/core.py
@@ -196,10 +196,10 @@ class NeuralLatentEncodeTransform(BaseMapTransform):
     def get_default_config() -> Dict[str, Any]:
         return {}
 
-    # @staticmethod
     def _apply_transform(self, audio_tree: AudioTree) -> AudioTree:
-        latents = self.encoder_fn(audio_tree)
-        audio_tree = audio_tree.replace(latents=latents)
+        if audio_tree.latents is None:
+            latents = self.encoder_fn(audio_tree)
+            audio_tree = audio_tree.replace(latents=latents)
         return audio_tree
 
 

--- a/src/audiotree/transforms/core.py
+++ b/src/audiotree/transforms/core.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List, Union
 
 from einops import rearrange
 from grain import python as grain
@@ -161,6 +161,48 @@ class SwapStereo(BaseMapTransform):
         return _swap_stereo_audio_transform(audio_tree)
 
 
+class NeuralLatentEncodeTransform(BaseMapTransform):
+    """Use a neural network to set the latents of the AudioTree.
+
+    .. code-block:: python
+
+        @staticmethod
+        def get_default_config() -> Dict[str, Any]:
+            return {}
+    """
+
+    def __init__(
+        self,
+        encoder_fn: Callable[[AudioTree], jnp.ndarray],
+        config: Dict[str, Dict[str, Any]] = None,
+        scope: Dict[str, Dict[str, Any]] = None,
+        output_key: Union[str, Callable[[List[str]], str]] = None,
+    ):
+        """
+        Initialize the base transform with a configuration, a flag for seed splitting, a probability, a scope, and an
+        output key.
+
+        Args:
+            encoder_fn (Callable[[AudioTree], jnp.ndarray]): A function that takes an audio_tree and returns a latent sequence.
+            config (Dict[str, Dict[str, Any]]): Configuration dictionary for the transform
+            scope (Dict[str, Dict[str, Any]]): Dictionary indicating which modalities to apply the transform to
+            output_key (Union[str, Callable[[List[str]], str]], optional): Key under which to store the transformed
+                value. By default, the values will be transformed in-place.
+        """
+        self.encoder_fn = encoder_fn
+        super().__init__(config, scope, output_key)
+
+    @staticmethod
+    def get_default_config() -> Dict[str, Any]:
+        return {}
+
+    # @staticmethod
+    def _apply_transform(self, audio_tree: AudioTree) -> AudioTree:
+        latents = self.encoder_fn(audio_tree)
+        audio_tree = audio_tree.replace(latents=latents)
+        return audio_tree
+
+
 class CorruptPhase(BaseRandomTransform):
     """
     Perform a phase corruption on the audio. The phase shift range is in the range ``[-pi * amount, pi * amount]``, and
@@ -295,7 +337,7 @@ class NeuralAudioCodecEncodeTransform(grain.MapTransform):
         self.encode_audio_fn = encode_audio_fn
         self.num_codebooks = num_codebooks
 
-    def map(self, audio_signal: AudioTree):
+    def map(self, audio_tree: AudioTree):
 
         def append_codes(leaf):
             audio_data = leaf.audio_data
@@ -313,11 +355,9 @@ class NeuralAudioCodecEncodeTransform(grain.MapTransform):
         def is_leaf(x):
             return isinstance(x, AudioTree)
 
-        audio_signal = jax.tree_util.tree_map(
-            append_codes, audio_signal, is_leaf=is_leaf
-        )
+        audio_tree = jax.tree_util.tree_map(append_codes, audio_tree, is_leaf=is_leaf)
 
-        return audio_signal
+        return audio_tree
 
 
 class ReduceBatchTransform(grain.MapTransform):
@@ -325,7 +365,7 @@ class ReduceBatchTransform(grain.MapTransform):
     def __init__(self, sample_rate: int):
         self.sample_rate = sample_rate
 
-    def map(self, audio_signal: AudioTree) -> AudioTree:
+    def map(self, audio_tree: AudioTree) -> AudioTree:
 
         def f(leaf):
             if isinstance(leaf, (np.ndarray, jnp.ndarray)):
@@ -335,6 +375,6 @@ class ReduceBatchTransform(grain.MapTransform):
                     return leaf.reshape(shape)
             return leaf
 
-        audio_signal = jax.tree_util.tree_map(f, audio_signal)
+        audio_tree = jax.tree_util.tree_map(f, audio_tree)
 
-        return audio_signal
+        return audio_tree

--- a/src/audiotree/transforms/core.py
+++ b/src/audiotree/transforms/core.py
@@ -373,8 +373,8 @@ class NeuralAudioCodecEncodeTransform(BaseMapTransform):
 
 class ReduceBatchTransform(grain.MapTransform):
 
-    def __init__(self, sample_rate: int):
-        self.sample_rate = sample_rate
+    def __init__(self):
+        pass
 
     def map(self, audio_tree: AudioTree) -> AudioTree:
 
@@ -386,6 +386,6 @@ class ReduceBatchTransform(grain.MapTransform):
                     return leaf.reshape(shape)
             return leaf
 
-        audio_tree = jax.tree_util.tree_map(f, audio_tree)
+        audio_tree = jax.tree.map(f, audio_tree)
 
         return audio_tree

--- a/src/audiotree/transforms/core.py
+++ b/src/audiotree/transforms/core.py
@@ -183,7 +183,8 @@ class NeuralLatentEncodeTransform(BaseMapTransform):
         output key.
 
         Args:
-            encoder_fn (Callable[[AudioTree], jnp.ndarray]): A function that takes an audio_tree and returns a latent sequence.
+            encoder_fn (Callable[[AudioTree], jnp.ndarray]): A function that takes an audio_tree and returns a latent
+                sequence.
             config (Dict[str, Dict[str, Any]]): Configuration dictionary for the transform
             scope (Dict[str, Dict[str, Any]]): Dictionary indicating which modalities to apply the transform to
             output_key (Union[str, Callable[[List[str]], str]], optional): Key under which to store the transformed
@@ -317,46 +318,56 @@ class Choose(grain.RandomMapTransform):
         return element
 
 
-class NeuralAudioCodecEncodeTransform(grain.MapTransform):
+class NeuralAudioCodecEncodeTransform(BaseMapTransform):
     """
     Use a neural audio codec such as `Descript Audio Codec (DAC) or EnCodec <https://github.com/DBraun/DAC-JAX>`_ to
     encode audio into tokens.
 
-    Args:
-        encode_audio_fn (Callable): A jitted function that takes audio shaped ``(B, C, T)`` and returns tokens
-            shaped ``((B C), K, S)``, where ``T`` is length in samples, ``S`` is encoded sequence length, and ``K`` is
-            number of codebooks.
-        num_codebooks (int): The number of codebooks in the codec.
+    .. code-block:: python
+
+        @staticmethod
+        def get_default_config() -> Dict[str, Any]:
+            return {}
     """
 
     def __init__(
         self,
-        encode_audio_fn: Callable[[jnp.ndarray], jnp.ndarray],
+        encoder_fn: Callable[[AudioTree], jnp.ndarray],
         num_codebooks: int,
+        config: Dict[str, Dict[str, Any]] = None,
+        scope: Dict[str, Dict[str, Any]] = None,
+        output_key: Union[str, Callable[[List[str]], str]] = None,
     ):
-        self.encode_audio_fn = encode_audio_fn
+        """
+        Initialize the base transform with a configuration, a flag for seed splitting, a probability, a scope, and an
+        output key.
+
+        Args:
+            encoder_fn (Callable[[AudioTree], jnp.ndarray]): A function that takes audio shaped ``(B, C, T)`` and
+                returns tokens shaped ``((B C), K, S)``, where ``T`` is length in samples, ``S`` is encoded sequence
+                length, and ``K`` is number of codebooks.
+            num_codebooks (int): The number of codebooks in the codec.
+            config (Dict[str, Dict[str, Any]]): Configuration dictionary for the transform
+            scope (Dict[str, Dict[str, Any]]): Dictionary indicating which modalities to apply the transform to
+            output_key (Union[str, Callable[[List[str]], str]], optional): Key under which to store the transformed
+                value. By default, the values will be transformed in-place.
+        """
+        self.encoder_fn = encoder_fn
         self.num_codebooks = num_codebooks
+        super().__init__(config, scope, output_key)
 
-    def map(self, audio_tree: AudioTree):
+    @staticmethod
+    def get_default_config() -> Dict[str, Any]:
+        return {}
 
-        def append_codes(leaf):
-            audio_data = leaf.audio_data
-            B, C, T = audio_data.shape
-
-            codes = self.encode_audio_fn(audio_data)
-
+    def _apply_transform(self, audio_tree: AudioTree) -> AudioTree:
+        if audio_tree.codes is None:
+            B, C, T = audio_tree.audio_data.shape
+            codes = self.encoder_fn(audio_tree)
             codes = rearrange(
                 codes, "(B C) K S -> B (K C) S", B=B, C=C, K=self.num_codebooks
             )
-
-            leaf = leaf.replace(codes=codes)
-            return leaf
-
-        def is_leaf(x):
-            return isinstance(x, AudioTree)
-
-        audio_tree = jax.tree_util.tree_map(append_codes, audio_tree, is_leaf=is_leaf)
-
+            audio_tree = audio_tree.replace(codes=codes)
         return audio_tree
 
 

--- a/src/audiotree/transforms/helpers.py
+++ b/src/audiotree/transforms/helpers.py
@@ -73,7 +73,6 @@ def _db2linear(decibels):
     return jnp.pow(10.0, decibels / 20.0)
 
 
-@jax.jit
 def _volume_norm_transform(
     audio_tree: AudioTree, key: jax.Array, min_db: float, max_db: float
 ) -> AudioTree:
@@ -93,7 +92,6 @@ def _volume_norm_transform(
     return audio_tree
 
 
-@jax.jit
 def _volume_change_transform(
     audio_tree: AudioTree, key: jax.Array, min_db: float, max_db: float
 ) -> (tuple)[AudioTree, jnp.ndarray]:
@@ -112,7 +110,6 @@ def _volume_change_transform(
     return audio_tree, gain_db
 
 
-@jax.jit
 def _rescale_audio_transform(audio_tree: AudioTree) -> AudioTree:
     """Rescales audio to the range [-1, 1] only if the original audio exceeds those bounds. Useful if transforms have
     caused the audio to clip. It won't change the relative balance of multichannel audio.
@@ -126,22 +123,18 @@ def _rescale_audio_transform(audio_tree: AudioTree) -> AudioTree:
     return audio_tree.replace(audio_data=audio_data)
 
 
-@jax.jit
 def _invert_phase_audio_transform(audio_tree: AudioTree) -> AudioTree:
     audio_data = audio_tree.audio_data
     audio_data = -audio_data
     return audio_tree.replace(audio_data=audio_data)
 
 
-@jax.jit
 def _swap_stereo_audio_transform(audio_tree: AudioTree) -> AudioTree:
     audio_data = audio_tree.audio_data
     audio_data = jnp.flip(audio_data, axis=1)
     return audio_tree.replace(audio_data=audio_data)
 
 
-# todo: potential slow-down with re-jitting due to changed static args
-@partial(jax.jit, static_argnums=(2, 3, 4, 5))
 def _corrupt_phase(
     audio_tree: AudioTree,
     rng: jax.Array,
@@ -173,8 +166,6 @@ def _corrupt_phase(
     return audio_tree.replace(audio_data=audio_data)
 
 
-# todo: potential slow-down with re-jitting due to changed static args
-@partial(jax.jit, static_argnums=(2, 3, 4, 5))
 def _shift_phase(
     audio_tree: AudioTree,
     key: jax.Array,

--- a/tests/datasources/.gitignore
+++ b/tests/datasources/.gitignore
@@ -1,0 +1,5 @@
+group1
+group2
+group3
+group4
+group5

--- a/tests/datasources/test_audiodatabalancedataset.py
+++ b/tests/datasources/test_audiodatabalancedataset.py
@@ -1,0 +1,37 @@
+import os.path
+
+import numpy as np
+import soundfile
+
+import audiotree.transforms
+from audiotree.datasources import AudioDataBalancedDataset
+
+
+def test_audiodatabalancedataset():
+
+    sample_rate = 44_100
+
+    data = np.zeros((5000, 1))
+    for g in range(1, 3):
+        os.makedirs(f"group{g}", exist_ok=True)
+        for i in range(5 + g * 5):
+            outpath = f"group{g}/tmp_{str(i).zfill(4)}.wav"
+            if not os.path.exists(outpath):
+                soundfile.write(outpath, data, sample_rate)
+
+    dataset = (
+        AudioDataBalancedDataset(
+            sources={"group1": ["group1"], "group2": ["group2"]},
+            sample_rate=sample_rate,
+            duration=0.01,
+            weights={"group1": 1, "group2": 2},  # show group2 twice as much as group 1.
+        )
+        .batch(1)
+        .map(audiotree.transforms.ReduceBatchTransform(sample_rate))
+    )
+    i = 0
+    for item in dataset:
+        print(item.filepath)
+        i += 1
+        if i > 100:
+            break

--- a/tests/datasources/test_audiodatabalancedataset.py
+++ b/tests/datasources/test_audiodatabalancedataset.py
@@ -27,7 +27,7 @@ def test_audiodatabalancedataset():
             weights={"group1": 1, "group2": 2},  # show group2 twice as much as group 1.
         )
         .batch(1)
-        .map(audiotree.transforms.ReduceBatchTransform(sample_rate))
+        .map(audiotree.transforms.ReduceBatchTransform())
     )
     i = 0
     for item in dataset:

--- a/tests/transforms/test_core.py
+++ b/tests/transforms/test_core.py
@@ -16,6 +16,7 @@ from audiotree.transforms import (
     RescaleAudio,
     InvertPhase,
     SwapStereo,
+    NeuralLatentEncodeTransform,
 )
 
 
@@ -42,15 +43,20 @@ class AddSomethingTransform(BaseMapTransform):
         }
 
     @staticmethod
-    def _apply_transform(element: jnp.ndarray, offset: int):
-        return element + offset
+    def _apply_transform(audio_tree: AudioTree, offset: int):
+        audio_data = audio_tree.audio_data + offset
+        audio_tree = audio_tree.replace(audio_data=audio_data)
+        return audio_tree
 
 
 @pytest.mark.parametrize("split_seed", [False, True])
 def test_config_001(split_seed: bool):
 
-    v = jnp.full((1,), fill_value=1)
-    element = {"a": v, "b": v, "c": [v, v], "d": {"e": v, "f": v}}
+    def make_tree(v: float):
+        return AudioTree(np.full(shape=(1, 1, 44_100), fill_value=v), 44_100)
+
+    audio_zero = make_tree(0.)
+    element = {"a": audio_zero, "b": audio_zero, "c": [audio_zero, audio_zero], "d": {"e": audio_zero, "f": audio_zero}}
 
     config = {
         "b": {"minval": -1, "maxval": 3},
@@ -63,9 +69,6 @@ def test_config_001(split_seed: bool):
     transform = ReturnConfigTransform(config=config, split_seed=split_seed)
     seed = 42
     transformed_element = transform.random_map(element, rng=np.random.default_rng(seed))
-    transformed_element = jax.tree.map(
-        lambda x: np.array(x).tolist(), transformed_element
-    )
 
     expected = {
         "a": {"minval": 0, "maxval": 1},
@@ -81,8 +84,12 @@ def test_config_001(split_seed: bool):
 
 def test_scope():
 
-    v = jnp.zeros((1,))
-    element = {"a": v, "b": v, "c": [v, v], "d": {"e": v, "f": v}, "g": [v, v]}
+    def make_tree(v: float):
+        return AudioTree(np.full(shape=(1, 1, 44_100), fill_value=v), 44_100)
+
+    audio_zero = make_tree(0.)
+    element = {"a": audio_zero, "b": audio_zero, "c": [audio_zero, audio_zero], "d": {"e": audio_zero, "f": audio_zero},
+               "g": [audio_zero, audio_zero]}
 
     scope = {
         "b": {"scope": True},
@@ -96,21 +103,18 @@ def test_scope():
 
     transform = AddSomethingTransform(scope=scope)
     transformed_element = transform.map(element)
-    transformed_element = jax.tree.map(
-        lambda x: np.array(x.reshape()).astype(int).tolist(), transformed_element
-    )
 
     expected = {
-        "a": 0,
-        "b": 1,
-        "c": [0, 0],
+        "a": make_tree(0),
+        "b": make_tree(1),
+        "c": [make_tree(0), make_tree(0)],
         "d": {
-            "e": 1,
-            "f": 0,
+            "e": make_tree(1),
+            "f": make_tree(0),
         },
-        "g": [1, 1],
+        "g": [make_tree(1), make_tree(1)],
     }
-    assert expected == transformed_element
+    assert are_equal_pytree(expected, transformed_element)
 
 
 def are_equal_pytree(pytree1, pytree2):
@@ -292,3 +296,24 @@ def test_transforms():
     RescaleAudio().map(audio_tree)
     InvertPhase().map(audio_tree)
     Identity().map(audio_tree)
+
+
+def test_only_apply_to_audiotree():
+
+    """Only `src` can have its `latents` set because `src` is an AudioTree while `other` is a simple array."""
+
+    def encoder_fn(audio_tree: AudioTree) -> jnp.ndarray:
+        B = audio_tree.audio_data.shape[0]
+        return jnp.zeros((B,))
+
+    B = 2
+
+    audio_data = {"src": AudioTree(audio_data=jnp.zeros(shape=(B, 1, 44100)), sample_rate=44100), "other": jnp.zeros((B,))}
+
+    transform = NeuralLatentEncodeTransform(encoder_fn=encoder_fn, scope={"src": {"scope": True}})
+    out = transform.map(audio_data)
+    assert out["src"].latents is not None
+
+    transform = NeuralLatentEncodeTransform(encoder_fn=encoder_fn)
+    out = transform.map(audio_data)
+    assert out["src"].latents is not None


### PR DESCRIPTION
* Use `jax.numpy` less in the dataloading in order to keep everything on CPU. Users can still jit audiotree transformations in their `train_step`.
* replace `AudioDataBalancedSource` with `AudioDataBalancedDataset`